### PR TITLE
`ActiveUsersSessionMiddleware` using `pk` as a universal attribute instead of `id`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/*
 *.egg-info
 *.pyc
 .tox/
+.venv
+venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # CHANGELOG
 
+## v0.4.1
+
+- Pycharm autoformat;
+- `ActiveUsersSessionMiddleware` using `pk` as a universal attribute instead of `id`;
+
 ## v0.4.0
 
 - Added support for Python 3.9, 3.10, 3.11
 - Added support for Django 4
 - Dropped support for Python 2.7, 3.4, 3.5
 - Dropped support for Django 1.x
-
 
 ## v0.3.0
 

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,4 +1,3 @@
 django>=1.11
 django-redis>=4.9.0
 six
-

--- a/active_users/api/__init__.py
+++ b/active_users/api/__init__.py
@@ -4,6 +4,7 @@ try:
 except ImportError:
     # FIXME: Django 2 compatibility
     from django.utils.encoding import force_text as force_str
+
 from django_redis import get_redis_connection
 
 from active_users.settings import active_users_settings as settings

--- a/active_users/api/urls.py
+++ b/active_users/api/urls.py
@@ -10,6 +10,7 @@ _patterns = [
 
 try:
     from django.conf.urls import patterns
+
     urlpatterns = patterns('', *_patterns)
 except ImportError:
     urlpatterns = _patterns

--- a/active_users/api/views.py
+++ b/active_users/api/views.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import json
+
 from django.http import HttpResponse
 
 from . import get_active_users
@@ -11,4 +12,5 @@ def active_users_info_view(request):
     # Compatible with Django 1.5, 1.6
     return HttpResponse(
         json.dumps({'data': data, 'count': len(data)}, ensure_ascii=False),
-        content_type='application/json')
+        content_type='application/json',
+    )

--- a/active_users/middleware.py
+++ b/active_users/middleware.py
@@ -25,7 +25,7 @@ class ActiveUsersSessionMiddleware(parent_class):
             if any(re.search(pat, request.path)
                    for pat in settings.EXCLUDE_URL_PATTERNS):
                 return
-        if request.user.id is not None:
+        if request.user.pk is not None:
             key = settings.KEY_CLASS.create_from_request(request)
             self.redis_client.setex(
                 name=key.dump(),

--- a/active_users/settings.py
+++ b/active_users/settings.py
@@ -40,7 +40,8 @@ def reload_settings(*args, **kwargs):
         key = kwargs['setting'].replace(PREFIX + '_', '')
         if key in DEFAULTS:
             active_users_settings.set_setting(
-                key, kwargs['value'] or DEFAULTS[key]
+                key,
+                kwargs['value'] or DEFAULTS[key]
             )
 
 

--- a/active_users/settings.py
+++ b/active_users/settings.py
@@ -1,13 +1,13 @@
 # coding:utf-8
 from django.conf import settings
 from django.test.signals import setting_changed
+
 try:
     from django.utils.module_loading import import_string
 except ImportError:
     from django.utils.module_loading import import_by_path as import_string
 
 from active_users.keys import AbstractActiveUserEntry
-
 
 PREFIX = 'ACTIVE_USERS'
 
@@ -40,7 +40,8 @@ def reload_settings(*args, **kwargs):
         key = kwargs['setting'].replace(PREFIX + '_', '')
         if key in DEFAULTS:
             active_users_settings.set_setting(
-                key, kwargs['value'] or DEFAULTS[key])
+                key, kwargs['value'] or DEFAULTS[key]
+            )
 
 
 setting_changed.connect(reload_settings)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-active-users',
-    version='0.4.0',
+    version='0.4.1',
     packages=['active_users', 'active_users.api'],
     url='https://github.com/n-elloco/django-active-users',
     license='MIT',


### PR DESCRIPTION
`ActiveUsersSessionMiddleware` using `pk` as a universal attribute instead of `id`